### PR TITLE
Support variable expansion in strings

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,3 +83,18 @@ class TestConfig(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             c1.merge(c2, allow_new_key=False)
+
+    def test_variable_expansion(self):
+        data = self.data.copy()
+        data['num_classes'] = 50
+        data['model']['num_classes'] = '$num_classes'
+
+        data['prefix'] = '/usr/share'
+        data['dataset']['root'] = '$prefix/data'
+
+        data['output'] = '$prefix/${model.name}'
+
+        config = mlconfig.load(data)
+        self.assertEqual(config['model']['num_classes'], 50)
+        self.assertEqual(config['dataset']['root'], '/usr/share/data')
+        self.assertEqual(config['output'], '/usr/share/LeNet')


### PR DESCRIPTION
I stumbled upon an issue when using `mlconfig` and trying to make my config relocatable.

Here's a simplified version for what I tried to do:

```yaml
prefix: `/some/path`
data:
  file: $prefix/data
```

But that resulted in a `KeyError: prefix/data`. After some quick digging, I found it was due to the logic in `mlconfig.Config._replace`. 

In this PR I aim for that code to allow the use case I described above.

The changes I made is to use python's [string.Template](https://docs.python.org/3/library/string.html#template-strings) if the key look up fails. I had to override the `braceidpattern` to allow it to expand nested values e.g. `${data.file}`. I chose to only include that feature in the brace expansion (`${…}`) to avoid confusion.

This feature should be fully backwards compatible.

I hope you'll find this feature useful.

Thanks