### PR TITLE
CI: add support for Python versions 3.12 and 3.13 in workflow

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/python.yaml` file to expand the supported Python versions in the CI workflow.

* [`.github/workflows/python.yaml`](diffhunk://#diff-d77f608d917ca9516006ca01edfe8b09e6bfbc79c66b4cbc3a14d617e94dd58aL17-R17): Added Python versions 3.12 and 3.13 to the matrix of supported versions.