### PR TITLE
[codex] Remove torch import print

### DIFF
--- a/src/mlconfig/torch/__init__.py
+++ b/src/mlconfig/torch/__init__.py
@@ -1,11 +1,8 @@
 import functools
 
-import mlconfig
+from torch import optim
 
-try:
-    from torch import optim
-except ImportError:
-    print("Failed to import torch.")
+import mlconfig
 
 
 def _register_classes(module, superclass, prefix=None, sep=".") -> None:


### PR DESCRIPTION
## Summary

- Remove the import-time `print` from `mlconfig.torch`.
- Let missing `torch` fail with the original `ImportError` instead of continuing to a later `NameError`.

## Validation

- `uv run pytest`
- `uv run ruff check src/mlconfig tests`
- `uv run ty check src tests --output-format concise`